### PR TITLE
remove default for pwgen mode

### DIFF
--- a/yspavectl
+++ b/yspavectl
@@ -55,7 +55,7 @@ parser = argparse.ArgumentParser(prog=pave.appname,description=actions,formatter
 parser.add_argument('--version', '-v', action='version', version='%(prog)s '+pave.appvers)
 parser.add_argument('--file','-f', help='Database file',nargs='?',default=pave.db_filename)
 parser.add_argument('--config-file','-c',help='Configuration file',nargs='?',default=pave.config_filename)
-parser.add_argument('--pwgen-mode','-m',choices=['print','p','alnum','a','xkcd','x'],default='a',nargs='?')
+parser.add_argument('--pwgen-mode','-m',choices=['print','p','alnum','a','xkcd','x'],nargs='?')
 parser.add_argument('action', choices=['migrate','new','add','edit','del','get','copy','pwgen','import'], default=None,nargs='?')
 parser.add_argument('query',default=None,nargs='?',help='ID for edit/del mode, search string for get mode')
 args = parser.parse_args()


### PR DESCRIPTION
    as `args.pwgen_mode` is always passed to `pave.PaveCfg()`, the setting in
    the config file is always overridden if a default is set